### PR TITLE
Small Improvements

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -1,0 +1,59 @@
+name: Docker
+
+on:
+  release:
+    types: [published]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Login against a Docker registry
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# env file
+.env
+
+# data directory
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.23.4 AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY . ./
+
+RUN CGO_ENABLED=0 go build -o railtail -ldflags="-w -s" ./.
+
+FROM gcr.io/distroless/static
+
+WORKDIR /app
+
+COPY --from=builder /app/railtail /usr/local/bin/railtail
+
+ENTRYPOINT ["/usr/local/bin/railtail"]

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ proxy, ensure you have a `http://` or `https://` in your `TARGET_ADDR`.
 | `TARGET_ADDR`        | `-target-addr` | Required. Address of the Tailscale node to send traffic to. |
 | `LISTEN_PORT`        | `-listen-port` | Required. Port to listen on.                                |
 | `TS_HOSTNAME`        | `-ts-hostname` | Required. Hostname to use for Tailscale.                    |
+| `TS_STATEDIR_PATH`   | `-ts-state-dir`| Optional. Tailscale state dir. Defaults to `/tmp/railtail`. |
 | `TS_AUTH_KEY`        | N/A            | Required. Tailscale auth key. Must be set in environment.   |
-| `TS_STATEDIR_PATH`   | N/A            | Optional. Tailscale state dir. Defaults to `/tmp/railtail`. |
 
 _CLI arguments will take precedence over environment variables._
 
@@ -80,12 +80,12 @@ connect to over Railway's Private Network.
    sudo tailscale up --reset --advertise-routes=172.31.0.0/16
    ```
 
-2. Deploy railtail to Railway by clicking the button below:
+2. Deploy railtail into your pre-existing Railway project:
 
    [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/template/railtail?referralCode=EPXG5z)
 
 3. Use your new railtail service's Private Domain to connect to your RDS instance:
 
    ```sh
-   DATABASE_URL="postgresql://u:p@${{railtail.RAILWAY_PRIVATE_DOMAIN}}:${{railtail.LISTEN_PORT}}/dbname"
+   DATABASE_URL="postgresql://username:password@${{railtail.RAILWAY_PRIVATE_DOMAIN}}:${{railtail.LISTEN_PORT}}/dbname"
    ```

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/half0wl/railtail
 go 1.23.4
 
 require (
-	go.uber.org/zap v1.27.0
+	golang.org/x/sync v0.9.0
 	tailscale.com v1.78.1
 )
 
@@ -72,14 +72,12 @@ require (
 	github.com/u-root/uio v0.0.0-20240118234441-a3c409a6018e // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
 	go4.org/mem v0.0.0-20220726221520-4f986261bf13 // indirect
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
 	golang.org/x/crypto v0.25.0 // indirect
 	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a // indirect
 	golang.org/x/mod v0.19.0 // indirect
 	golang.org/x/net v0.27.0 // indirect
-	golang.org/x/sync v0.9.0 // indirect
 	golang.org/x/sys v0.27.0 // indirect
 	golang.org/x/term v0.22.0 // indirect
 	golang.org/x/text v0.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -186,12 +186,6 @@ github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1Y
 github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
-go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
-go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
-go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
-go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
-go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 go4.org/mem v0.0.0-20220726221520-4f986261bf13 h1:CbZeCBZ0aZj8EfVgnqQcYZgf0lpZ3H9rmp5nkDTAst8=
 go4.org/mem v0.0.0-20220726221520-4f986261bf13/go.mod h1:reUoABIJ9ikfM5sgtSF3Wushcza7+WeD01VB9Lirh3g=
 go4.org/netipx v0.0.0-20231129151722-fdeea329fbba h1:0b9z3AuHCjxk0x/opv64kcgZLBseWJUpBw5I82+2U4M=

--- a/http.go
+++ b/http.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+)
+
+func fwdHttp(outboundClient *http.Client, targetAddr string, w http.ResponseWriter, r *http.Request) error {
+	var proxyError error
+
+	proxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL, _ = url.Parse(targetAddr + req.URL.RequestURI())
+			req.Host = req.URL.Host
+		},
+		Transport: outboundClient.Transport,
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			http.Error(w, "error proxying request", http.StatusBadGateway)
+
+			proxyError = err
+		},
+	}
+
+	proxy.ServeHTTP(w, r)
+
+	return proxyError
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/half0wl/railtail/internal/config/parser"
+)
+
+type ForwardTrafficType string
+
+const (
+	ForwardTrafficTypeTCP   ForwardTrafficType = "tcp"
+	ForwardTrafficTypeHTTP  ForwardTrafficType = "http"
+	ForwardTrafficTypeHTTPS ForwardTrafficType = "https"
+)
+
+var (
+	ErrTargetAddrInvalid = errors.New("target-addr is invalid")
+)
+
+type Config struct {
+	TSHostname     string `flag:"ts-hostname" env:"TS_HOSTNAME" usage:"hostname to use for tailscale"`
+	ListenPort     string `flag:"listen-port" env:"LISTEN_PORT" usage:"port to listen on"`
+	TargetAddr     string `flag:"target-addr" env:"TARGET_ADDR" usage:"address:port of a tailscale node to send traffic to"`
+	TSStateDirPath string `flag:"ts-state-dir" env:"TS_STATEDIR_PATH" default:"/tmp/railtail" usage:"tailscale state dir"`
+	TSAuthKey      string `env:"TS_AUTHKEY,TS_AUTH_KEY" usage:"tailscale auth key"`
+
+	ForwardTrafficType ForwardTrafficType
+}
+
+func init() {
+	// add help flag purly for the usage message
+	flag.Bool("help", false, "Show help message")
+
+	// Only parse and print usage if -help is present in arguments
+	if checkForFlag("help") {
+		// Create temporary config just to register all flags for usage message
+		cfg := &Config{}
+
+		parser.ParseFlags(cfg)
+
+		flag.Usage()
+		os.Exit(0)
+	}
+}
+
+func LoadConfig() (*Config, []error) {
+	cfg := &Config{}
+
+	errors := parser.ParseConfig(cfg)
+
+	// Validate target-addr if it's set to either be a valid URL with a port or a valid address:port
+	if cfg.TargetAddr != "" {
+		protocol := strings.SplitN(cfg.TargetAddr, "://", 2)[0]
+		switch protocol {
+		case "https", "http":
+			cfg.ForwardTrafficType = ForwardTrafficType(protocol)
+
+			u, err := url.Parse(cfg.TargetAddr)
+			if err != nil {
+				errors = append(errors, fmt.Errorf("%w: %w", ErrTargetAddrInvalid, err))
+			}
+
+			// Check if the URL has a port only if the URL is valid
+			if err == nil && u.Port() == "" {
+				errors = append(errors, fmt.Errorf("%w: address %s: missing port in address", ErrTargetAddrInvalid, cfg.TargetAddr))
+			}
+		default:
+			cfg.ForwardTrafficType = ForwardTrafficTypeTCP
+			_, _, err := net.SplitHostPort(cfg.TargetAddr)
+			if err != nil {
+				errors = append(errors, fmt.Errorf("%w: %w", ErrTargetAddrInvalid, err))
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return nil, errors
+	}
+
+	return cfg, nil
+}

--- a/internal/config/parser/parser.go
+++ b/internal/config/parser/parser.go
@@ -1,0 +1,90 @@
+package parser
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+)
+
+func ParseFlags(cfg any, t ...reflect.Type) map[string]*string {
+	flags := make(map[string]*string)
+
+	if len(t) == 0 {
+		v := reflect.ValueOf(cfg).Elem()
+		t = []reflect.Type{v.Type()}
+	}
+
+	// Register flags
+	for i := 0; i < t[0].NumField(); i++ {
+		field := t[0].Field(i)
+		if flagName := field.Tag.Get("flag"); flagName != "" {
+			flags[field.Name] = flag.String(flagName, "", field.Tag.Get("usage"))
+		}
+	}
+
+	flag.Parse()
+
+	return flags
+}
+
+func ParseConfig(cfg any) []error {
+	var errors []error
+
+	v := reflect.ValueOf(cfg).Elem()
+	t := v.Type()
+
+	flags := ParseFlags(cfg, t)
+
+	// Set values and collect errors
+	for i := range t.NumField() {
+		field := t.Field(i)
+		fieldValue := v.Field(i)
+
+		// Skip if field has no tags at all
+		if field.Tag == "" {
+			continue
+		}
+
+		// Check flag value first
+		if flagVal, ok := flags[field.Name]; ok && *flagVal != "" {
+			fieldValue.SetString(*flagVal)
+			continue // Skip env vars if flag is set
+		}
+
+		// If no flag value, check environment variables
+		for _, env := range strings.Split(field.Tag.Get("env"), ",") {
+			if val := os.Getenv(env); val != "" {
+				fieldValue.SetString(val)
+				break
+			}
+		}
+
+		// If no value set yet, use default value if present
+		if fieldValue.String() == "" {
+			if defaultVal := field.Tag.Get("default"); defaultVal != "" {
+				fieldValue.SetString(defaultVal)
+				continue
+			}
+		}
+
+		// collect errors only if no value is set and no default exists
+		if fieldValue.String() == "" {
+			flagName := field.Tag.Get("flag")
+			envVars := field.Tag.Get("env")
+
+			if flagName != "" {
+				errors = append(errors, fmt.Errorf("%s is required: set %s in env or use --%s", field.Name, envVars, flagName))
+			} else {
+				errors = append(errors, fmt.Errorf("%s is required: set one of: %s in env", field.Name, envVars))
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return errors
+	}
+
+	return nil
+}

--- a/internal/config/util.go
+++ b/internal/config/util.go
@@ -1,0 +1,15 @@
+package config
+
+import (
+	"os"
+)
+
+func checkForFlag(flagName string) bool {
+	for _, arg := range os.Args[1:] {
+		if arg == "-"+flagName || arg == "--"+flagName || arg == "-"+flagName[:1] || arg == "--"+flagName[:1] {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/logger/attr.go
+++ b/internal/logger/attr.go
@@ -1,0 +1,20 @@
+package logger
+
+import (
+	"log/slog"
+	"strings"
+)
+
+func ErrAttr(err error) slog.Attr {
+	return slog.String("err", strings.TrimSpace(err.Error()))
+}
+
+func ErrorsAttr(errors ...error) slog.Attr {
+	stringErrors := []string{}
+
+	for _, err := range errors {
+		stringErrors = append(stringErrors, strings.TrimSpace(err.Error()))
+	}
+
+	return slog.Any("errors", stringErrors)
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,31 @@
+package logger
+
+import (
+	"os"
+
+	"log/slog"
+)
+
+var (
+	stdoutHandler = slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{})
+	//enable source
+	stdoutHandlerWithSource = slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		AddSource: true,
+	})
+
+	stderrHandler = slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{})
+	// enable source
+	stderrHandlerWithSource = slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		AddSource: true,
+	})
+
+	// sends logs to stdout
+	Stdout = slog.New(stdoutHandler)
+	// sends logs to stdout with source info
+	StdoutWithSource = slog.New(stdoutHandlerWithSource)
+
+	// sends logs to stderr
+	Stderr = slog.New(stderrHandler)
+	// sends logs to stderr with source info
+	StderrWithSource = slog.New(stderrHandlerWithSource)
+)

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/half0wl/railtail/internal/config"
@@ -30,7 +31,7 @@ func main() {
 		UserLogf: func(format string, v ...any) {
 			logger.Stdout.Info(fmt.Sprintf(format, v...))
 		},
-		Dir: "./data/railtail",
+		Dir: filepath.Join(cfg.TSStateDirPath, "railtail"),
 	}
 	if err := ts.Start(); err != nil {
 		logger.StderrWithSource.Error("failed to start tailscale network server", logger.ErrAttr(err))
@@ -45,6 +46,7 @@ func main() {
 		slog.String("ts-hostname", cfg.TSHostname),
 		slog.String("listen-addr", listenAddr),
 		slog.String("target-addr", cfg.TargetAddr),
+		slog.String("ts-state-dir", filepath.Join(cfg.TSStateDirPath, "railtail")),
 	)
 
 	listener, err := net.Listen("tcp", listenAddr)

--- a/main.go
+++ b/main.go
@@ -1,238 +1,116 @@
 package main
 
 import (
-	"cmp"
-	"context"
 	"crypto/tls"
-	"flag"
 	"fmt"
-	"io"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
-	"slices"
-	"strings"
 	"time"
 
-	"go.uber.org/zap"
+	"github.com/half0wl/railtail/internal/config"
+	"github.com/half0wl/railtail/internal/logger"
+
 	"tailscale.com/tsnet"
 )
 
-const (
-	DEFAULT_TS_STATE_DIR = "/tmp/railtail"
-)
-
-var (
-	tsHostname     = flag.String("ts-hostname", "", "hostname to use for tailscale (or set env: TS_HOSTNAME)")
-	listenPort     = flag.String("listen-port", "", "port to listen on (or set env: LISTEN_PORT)")
-	targetAddr     = flag.String("target-addr", "", "address:port of a tailscale node to send traffic to (or set env: TARGET_ADDR)")
-	tsStateDirPath = cmp.Or(os.Getenv("TS_STATEDIR_PATH"), DEFAULT_TS_STATE_DIR)
-	tsAuthKey      = cmp.Or(os.Getenv("TS_AUTH_KEY"), "")
-)
-
-var httpHopHeaders = []string{
-	"Connection",
-	"Keep-Alive",
-	"Proxy-Authenticate",
-	"Proxy-Authorization",
-	"Trailers",
-	"Transfer-Encoding",
-	"Upgrade",
-	"Te",
-}
-
 func main() {
-	zapLgr, err := zap.NewProduction()
-	if err != nil {
-		log.Fatal(err)
-	}
-	logger := zapLgr.Sugar()
-	defer logger.Sync()
-
-	flag.Parse()
-
-	if tsAuthKey == "" {
-		logger.Fatal("env TS_AUTH_KEY is required")
-	}
-
-	// Grab config from env if not provided in args. Args take precedence.
-	if *tsHostname == "" {
-		*tsHostname = os.Getenv("TS_HOSTNAME")
-	}
-	if *tsHostname == "" {
-		logger.Fatal("ts-hostname is required (set TS_HOSTNAME in env or use -ts-hostname)")
-	}
-
-	if *listenPort == "" {
-		*listenPort = os.Getenv("LISTEN_PORT")
-	}
-	if *listenPort == "" {
-		logger.Fatal("listen-port is required (set LISTEN_PORT in env or use -listen-port)")
-	}
-
-	if *targetAddr == "" {
-		*targetAddr = os.Getenv("TARGET_ADDR")
-	}
-	if *targetAddr == "" {
-		logger.Fatal("target-addr is required (set TARGET_ADDR in env or use -target-addr)")
+	cfg, errs := config.LoadConfig()
+	if len(errs) > 0 {
+		logger.StderrWithSource.Error("configuration error(s) found", logger.ErrorsAttr(errs...))
+		os.Exit(1)
 	}
 
 	ts := &tsnet.Server{
-		Hostname:     *tsHostname,
-		AuthKey:      tsAuthKey,
-		Dir:          tsStateDirPath,
+		Hostname:     cfg.TSHostname,
+		AuthKey:      cfg.TSAuthKey,
 		RunWebClient: false,
 		Ephemeral:    false,
+		UserLogf: func(format string, v ...any) {
+			logger.Stdout.Info(fmt.Sprintf(format, v...))
+		},
+		Dir: "./data/railtail",
 	}
 	if err := ts.Start(); err != nil {
-		logger.Fatalf("can't start tsnet server: %v", err)
+		logger.StderrWithSource.Error("failed to start tailscale network server", logger.ErrAttr(err))
+		os.Exit(1)
 	}
+
 	defer ts.Close()
 
-	mode := "TCP"
-	if strings.HasPrefix(*targetAddr, "http://") || strings.HasPrefix(*targetAddr, "https://") {
-		mode = "HTTP"
-	}
+	listenAddr := "[::]:" + cfg.ListenPort
 
-	listenAddr := "[::]:" + *listenPort
+	logger.Stdout.Info("🚀 Starting railtail",
+		slog.String("ts-hostname", cfg.TSHostname),
+		slog.String("listen-addr", listenAddr),
+		slog.String("target-addr", cfg.TargetAddr),
+	)
 
-	logger.Infof("🚀 Starting railtail")
-	logger.Infof("Mode                 : %s", mode)
-	logger.Infof("Listening on         : %s", listenAddr)
-	logger.Infof("Sending traffic to   : %s", *targetAddr)
-	logger.Infof("Tailscale hostname   : %s", *tsHostname)
-	logger.Infof("Tailscale state dir  : %s", tsStateDirPath)
-
-	if mode == "TCP" {
-		runTcp(logger, listenAddr, ts, *targetAddr)
-		return
-	}
-
-	if mode == "HTTP" {
-		runHttp(logger, listenAddr, ts, *targetAddr)
-		return
-	}
-
-	logger.Fatalf("unsupported mode: %s", mode)
-}
-
-func handleTcpConn(logger *zap.SugaredLogger, lstConn net.Conn, ts *tsnet.Server, target string) {
-	defer lstConn.Close()
-
-	logger.Infof("[tcp] fwd: %s -> %s -> %s", lstConn.LocalAddr(), lstConn.RemoteAddr(), target)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	tsConn, err := ts.Dial(ctx, "tcp", target)
-	if err != nil {
-		logger.Errorf("ts dial failed: %v", err)
-		return
-	}
-
-	lstChan, tsChan := make(chan int64), make(chan int64)
-	go func() {
-		defer tsConn.Close()
-		n, _ := io.Copy(tsConn, lstConn)
-		lstChan <- int64(n)
-	}()
-	go func() {
-		defer lstConn.Close()
-		n, _ := io.Copy(lstConn, tsConn)
-		tsChan <- int64(n)
-	}()
-	<-lstChan
-	<-tsChan
-}
-
-func handleHttpConn(logger *zap.SugaredLogger, outboundClient *http.Client, targetAddr string, w http.ResponseWriter, r *http.Request) {
-	targetUri := fmt.Sprintf("%s%s", targetAddr, r.URL.Path)
-
-	logger.Infof("[http] fwd %s (%s) -> %s %s", r.RemoteAddr, r.URL.Path, r.Method, targetUri)
-
-	outReq, err := http.NewRequest(r.Method, targetUri, r.Body)
-	if err != nil {
-		logger.Errorf("error creating request: %v", err)
-		http.Error(w, "error creating request", http.StatusInternalServerError)
-		return
-	}
-
-	// Copy headers: in -> out
-	for name, values := range r.Header {
-		for _, value := range values {
-			// Skip hop-by-hop headers
-			if slices.Contains(httpHopHeaders, name) {
-				continue
-			}
-			outReq.Header.Add(name, value)
-		}
-	}
-
-	resp, err := outboundClient.Do(outReq)
-	if err != nil {
-		logger.Errorf("error sending request: %v", err)
-		http.Error(w, "error sending request", http.StatusInternalServerError)
-		return
-	}
-	defer resp.Body.Close()
-
-	// Copy headers: out (resp) -> in
-	for name, values := range resp.Header {
-		for _, value := range values {
-			// Skip hop-by-hop headers
-			if slices.Contains(httpHopHeaders, name) {
-				continue
-			}
-			w.Header().Add(name, value)
-		}
-	}
-
-	if upstreamIp, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
-		w.Header().Set("X-Forwarded-For", upstreamIp)
-	}
-
-	w.WriteHeader(resp.StatusCode)
-	io.Copy(w, resp.Body)
-}
-
-func runTcp(logger *zap.SugaredLogger, listenAddr string, ts *tsnet.Server, targetAddr string) {
 	listener, err := net.Listen("tcp", listenAddr)
 	if err != nil {
-		logger.Fatalf("unable to start listener: %v", err)
+		logger.StderrWithSource.Error("failed to start local listener", logger.ErrAttr(err))
+		os.Exit(1)
 	}
+
+	if cfg.ForwardTrafficType == config.ForwardTrafficTypeHTTP || cfg.ForwardTrafficType == config.ForwardTrafficTypeHTTPS {
+		logger.Stdout.Info("running in HTTP/s proxy mode (http(s):// scheme detected in targetAddr)",
+			slog.String("listen-addr", listenAddr),
+			slog.String("target-addr", cfg.TargetAddr),
+		)
+
+		httpClient := ts.HTTPClient()
+		httpClient.Transport.(*http.Transport).TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+
+		server := http.Server{
+			IdleTimeout:       60 * time.Second,
+			ReadHeaderTimeout: 5 * time.Second,
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				forwardingInfo := []any{
+					slog.String("remote-addr", r.RemoteAddr),
+					slog.String("target", cfg.TargetAddr),
+				}
+
+				logger.Stdout.Info("forwarding", forwardingInfo...)
+
+				if err := fwdHttp(httpClient, cfg.TargetAddr, w, r); err != nil {
+					logger.StderrWithSource.Error("failed to forward http request", append([]any{logger.ErrAttr(err)}, forwardingInfo...)...)
+				}
+			}),
+		}
+
+		if err := server.Serve(listener); err != nil {
+			logger.StderrWithSource.Error("failed to start http server", logger.ErrAttr(err))
+			os.Exit(1)
+		}
+	}
+
+	logger.Stdout.Info("running in TCP tunnel mode (no HTTP scheme detected in targetAddr)",
+		slog.String("listen-addr", listenAddr),
+		slog.String("target-addr", cfg.TargetAddr),
+	)
+
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
-			logger.Errorf("listener accept failed: %v", err)
+			logger.StderrWithSource.Error("failed to accept connection", logger.ErrAttr(err))
+			continue
 		}
-		go handleTcpConn(logger, conn, ts, targetAddr)
-	}
-}
 
-func runHttp(logger *zap.SugaredLogger, listenAddr string, ts *tsnet.Server, targetAddr string) {
-	httpClient := ts.HTTPClient()
-	httpClient.Timeout = 5 * time.Minute
-	httpClient.Transport = &http.Transport{
-		Dial: (&net.Dialer{
-			Timeout:   5 * time.Minute,
-			KeepAlive: 5 * time.Minute,
-		}).Dial,
-		DialContext:     ts.Dial,
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-	httpServer := http.Server{
-		Addr:              listenAddr,
-		ReadTimeout:       15 * time.Second,
-		WriteTimeout:      15 * time.Second,
-		IdleTimeout:       60 * time.Second,
-		ReadHeaderTimeout: 5 * time.Second,
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			handleHttpConn(logger, httpClient, targetAddr, w, r)
-		}),
-	}
-	err := httpServer.ListenAndServe()
-	if err != nil {
-		logger.Fatalf("unable to start http server: %v", err)
+		forwardingInfo := []any{
+			slog.String("local-addr", conn.LocalAddr().String()),
+			slog.String("remote-addr", conn.RemoteAddr().String()),
+			slog.String("target", cfg.TargetAddr),
+		}
+
+		logger.Stdout.Info("forwarding tcp connection", forwardingInfo...)
+
+		go func() {
+			if err := fwdTCP(conn, ts, cfg.TargetAddr); err != nil {
+				logger.StderrWithSource.Error("forwarding failed", append([]any{logger.ErrAttr(err)}, forwardingInfo...)...)
+			}
+		}()
 	}
 }

--- a/tcp.go
+++ b/tcp.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+
+	"golang.org/x/sync/errgroup"
+	"tailscale.com/tsnet"
+)
+
+func fwdTCP(lstConn net.Conn, ts *tsnet.Server, targetAddr string) error {
+	defer lstConn.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tsConn, err := ts.Dial(ctx, "tcp", targetAddr)
+	if err != nil {
+		return fmt.Errorf("failed to dial tailscale node: %w", err)
+	}
+
+	defer tsConn.Close()
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		_, err := io.Copy(tsConn, lstConn)
+		return fmt.Errorf("failed to copy data to tailscale node: %w", err)
+	})
+
+	g.Go(func() error {
+		_, err := io.Copy(lstConn, tsConn)
+		return fmt.Errorf("failed to copy data from tailscale node: %w", err)
+	})
+
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("connection error: %w", err)
+	}
+
+	return nil
+}

--- a/tcp.go
+++ b/tcp.go
@@ -26,13 +26,19 @@ func fwdTCP(lstConn net.Conn, ts *tsnet.Server, targetAddr string) error {
 	g, ctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		_, err := io.Copy(tsConn, lstConn)
-		return fmt.Errorf("failed to copy data to tailscale node: %w", err)
+		if _, err := io.Copy(tsConn, lstConn); err != nil {
+			return fmt.Errorf("failed to copy data to tailscale node: %w", err)
+		}
+
+		return nil
 	})
 
 	g.Go(func() error {
-		_, err := io.Copy(lstConn, tsConn)
-		return fmt.Errorf("failed to copy data from tailscale node: %w", err)
+		if _, err := io.Copy(lstConn, tsConn); err != nil {
+			return fmt.Errorf("failed to copy data from tailscale node: %w", err)
+		}
+
+		return nil
 	})
 
 	if err := g.Wait(); err != nil {


### PR DESCRIPTION
- Break TCP and HTTP forwarders into their own funcs.
- Handle bi-directional errors from TCP copying.
- Unified config format.
- Move to stdlib slog.
- Store state in a configurable directory.
- Add Dockerfile
- Add ghcr image build script.
- Add support for `--help`
- Use built in `httputil.ReverseProxy` for http proxy.

And some other misc stuff.